### PR TITLE
Version 3

### DIFF
--- a/docker/nextjs/Dockerfile
+++ b/docker/nextjs/Dockerfile
@@ -1,12 +1,12 @@
-FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20.9.0-slim as builder
+FROM --platform=linux/arm64 public.ecr.aws/docker/library/node:20.9.0-slim AS builder
 WORKDIR /app
 
 COPY . .
 RUN npm install -g pnpm
 RUN pnpm i && pnpm run build
 
-FROM public.ecr.aws/docker/library/node:20.9.0-slim as runner
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.8.4 /lambda-adapter /opt/extensions/lambda-adapter
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/node:20.9.0-slim AS runner
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.0-x86_64 /lambda-adapter /opt/extensions/lambda-adapter
 
 ENV PORT=3000 NODE_ENV=production AWS_LWA_INVOKE_MODE=response_stream
 

--- a/lib/constructs/ad.ts
+++ b/lib/constructs/ad.ts
@@ -198,5 +198,10 @@ export class Ad extends Construct {
     new cdk.CfnOutput(this, "GetSecretValueCommand", {
       value: `aws secretsmanager get-secret-value --secret-id ${this.adPasswoed.secretName} --query SecretString --output text --profile YOUR_AWS_PROFILE | jq -r '.password' `,
     });
+
+    new cdk.CfnOutput(this, 'AdPasswdArnOutput', {
+      value: this.adPasswoed.secretArn,
+      exportName: 'AdPasswdArn',
+    });
   }
 }

--- a/lib/constructs/lambda-web-adapter.ts
+++ b/lib/constructs/lambda-web-adapter.ts
@@ -81,7 +81,7 @@ export class LambdaWebAdapter extends Construct {
       code: DockerImageCode.fromEcr(chatAppRepository.repository, {
         tagOrDigest: props.tag,
       }),
-      architecture: Architecture.ARM_64,
+      architecture: Architecture.X86_64,
       memorySize: 2048,
       timeout: cdk.Duration.minutes(5),
       environment: {

--- a/lib/constructs/network.ts
+++ b/lib/constructs/network.ts
@@ -19,17 +19,10 @@ import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 import { isEmpty } from "lodash";
 import { NetworkConfig } from "../../types/type";
-// import { IHostedZone, PublicHostedZone } from "aws-cdk-lib/aws-route53";
-// import {
-//   Certificate,
-//   CertificateValidation,
-// } from "aws-cdk-lib/aws-certificatemanager";
-// import { DomainRegister } from "./domain";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 
 export class Network extends Construct {
   public readonly vpc: Vpc | IVpc;
-  // public readonly hostZone: IHostedZone | PublicHostedZone;
-  // public readonly certificate: Certificate;
   constructor(scope: Construct, id: string, props: NetworkConfig) {
     super(scope, id);
 
@@ -97,18 +90,9 @@ export class Network extends Construct {
         service: InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
       });
     }
-
-    // const domain = new DomainRegister({
-    //   construct: this,
-    //   appDomainName: props.appDomainName,
-    //   existingRoute53: props.existingRoute53,
-    // });
-
-    // this.hostZone = domain.hostedZone;
-
-    // this.certificate = new Certificate(this, "Cert", {
-    //   domainName: props.appDomainName,
-    //   validation: CertificateValidation.fromDns(this.hostZone),
-    // });
+    new StringParameter(this, 'VpcId', {
+      parameterName:'VpcId',
+      stringValue: this.vpc.vpcId
+    })
   }
 }

--- a/lib/fsxn-stack.ts
+++ b/lib/fsxn-stack.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: LicenseRef-.amazon.com.-AmznSL-1.0
+ *  Licensed under the Amazon Software License  http://aws.amazon.com/asl/
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { Network } from "./constructs/network";
+import { devConfig } from "../config";
+import { FSxN } from "./constructs/fsx";
+import { Ad } from "./constructs/ad";
+
+export class FSxNStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const network = new Network(this, `${id}-Network`, {
+      ...devConfig.networkConfig,
+    });
+
+    const ad = new Ad(this, `${id}-Ad`, {
+      vpc: network.vpc,
+      ...devConfig.adConfig,
+    });
+
+    const fsx = new FSxN(this, `${id}-FSx`, {
+      vpc: network.vpc,
+      ad: ad.microsoftAd,
+      adPassword: ad.adPasswoed,
+      ...devConfig.adConfig,
+    });
+  }
+}


### PR DESCRIPTION
注意事項：
1.	ログイン画面の画像について 以下のパスがChatbotのログイン時の画像を置いてあるパスとなっております。現在は広島大学でのハンズオンを実施するために、こちらの画像としていますが利用方法に応じて変えていただければと思います。 docker/nextjs/public/images/main-image.JPG
2.	スタック指定時のデプロイ時のコマンドの変更 以下のように分けてデプロイ、あるいはCIFSのボリューム名、RAG DBボリューム名を指定もできるようにしています。

#一括の場合
npm run cdk deploy -- --all --profile test

#分ける場合
npm run cdk context -- --clear
npm run cdk ls  -- --profile test
npm run cdk deploy -- user01Us user01Ad --profile test npm run cdk deploy -- user01FSx --profile test
npm run cdk deploy -- user01Compute --profile test

#既存ボリュームがある場合
CIFSDATA_VOL_NAME=XXX RAGDB_VOL_PATH='/xxxx' npm run cdk deploy -- user01Compute --profile test

以下にVersion 2からの代表的な変更、修正点を抜粋します。

変更点抜粋
1.	AD分離、Stack名にUser名を追加する仕組み、Lambdaのサブネットを指定
2.	Embedding Serverのエラーを修正
3.	AD Host Keyの重複問題に対応
4.	Managed AD構築時にPrivate Subnetが2つだけじゃない場合に発生するエラーを修正
5.	Aurora Serverlessのセッションがクローズされずにクォータに到達するエラーを修正
6.	Docker終了時のリスタート設定を追加
7.	Cognito Tempパス、Claudeモデル除外設定、ChatbotのWelcomeメッセージで基盤モデルを名乗らないように修正